### PR TITLE
Replace `.c_str()` with direct string usage in logging functions for …

### DIFF
--- a/components/eqiva_key_ble/eqiva_key_ble.cpp
+++ b/components/eqiva_key_ble/eqiva_key_ble.cpp
@@ -16,7 +16,7 @@ static const char *const TAG = "eqiva_key_ble";
 
 void EqivaKeyBle::dump_config() {
   ESP_LOGCONFIG(TAG, "Eqiva Key-BLE:");
-  ESP_LOGCONFIG(TAG, "  Address: %s", this->address_str().c_str());
+  ESP_LOGCONFIG(TAG, "  Address: %s", this->address_str());
   ESP_LOGCONFIG(TAG, "  UserKey: %s", clientState.user_key.length() > 0 ? string_to_hex(clientState.user_key).c_str() : "");
   ESP_LOGCONFIG(TAG, "  UserId: %d", clientState.user_id);
   ESP_LOGCONFIG(TAG, "  CardKey: %s", clientState.card_key.c_str());

--- a/components/eqiva_key_ble/eqiva_key_ble.h
+++ b/components/eqiva_key_ble/eqiva_key_ble.h
@@ -165,7 +165,7 @@ class EqivaConnect : public Action<Ts...>, public Parented<EqivaKeyBle> {
             this->parent_->set_user_id(user_id);
             this->parent_->set_user_key(user_key);
             this->parent_->set_address(string_to_mac(mac_address));
-            ESP_LOGD("ESP Eqiva", " Address: %s, %s", this->parent_->address_str().c_str(), mac_address.c_str());
+            ESP_LOGD("ESP Eqiva", " Address: %s, %s", this->parent_->address_str(), mac_address.c_str());
 
         }
 };


### PR DESCRIPTION
update for compile errors in ESPHOME 2025.12.0