### PR TITLE
fix for esphome 2026.03

### DIFF
--- a/components/eqiva_ble/__init__.py
+++ b/components/eqiva_ble/__init__.py
@@ -17,7 +17,15 @@ CONFIG_SCHEMA = cv.Schema(
     }
 ).extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
 
-
-def to_code(config):
+async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    yield esp32_ble_tracker.register_ble_device(var, config)
+    await esp32_ble_tracker.register_ble_device(var, config)
+```
+
+Save this as `/config/esphome/components/eqiva_ble/__init__.py` alongside the other patched file. Your local components folder should now look like:
+```
+/config/esphome/components/
+  eqiva_ble/
+    __init__.py        ← patched (yield → async/await)
+  eqiva_key_ble/
+    __init__.py        ← patched (synchronous=False)

--- a/components/eqiva_ble/__init__.py
+++ b/components/eqiva_ble/__init__.py
@@ -20,12 +20,3 @@ CONFIG_SCHEMA = cv.Schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await esp32_ble_tracker.register_ble_device(var, config)
-```
-
-Save this as `/config/esphome/components/eqiva_ble/__init__.py` alongside the other patched file. Your local components folder should now look like:
-```
-/config/esphome/components/
-  eqiva_ble/
-    __init__.py        ← patched (yield → async/await)
-  eqiva_key_ble/
-    __init__.py        ← patched (synchronous=False)

--- a/components/eqiva_ble/eqiva_listener.cpp
+++ b/components/eqiva_ble/eqiva_listener.cpp
@@ -12,7 +12,7 @@ static const char *const TAG = "eqiva_ble";
 bool EqivaListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
     for (auto &it : device.get_manufacturer_datas()) {
         if (it.uuid == esp32_ble_tracker::ESPBTUUID::from_uint16(0x1A00)) {
-            ESP_LOGI(TAG, "Found Eqiva device (MAC: %s) (UUID): %s  (Name): %s", device.address_str().c_str(), it.uuid.to_str().c_str(), device.get_name().c_str());
+            ESP_LOGI(TAG, "Found Eqiva device (MAC: %s) (UUID): %s  (Name): %s", device.address_str().c_str(), it.uuid.to_string().c_str(), device.get_name().c_str());
             return true;
         }
     }

--- a/components/eqiva_ble/eqiva_listener.cpp
+++ b/components/eqiva_ble/eqiva_listener.cpp
@@ -12,7 +12,7 @@ static const char *const TAG = "eqiva_ble";
 bool EqivaListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
     for (auto &it : device.get_manufacturer_datas()) {
         if (it.uuid == esp32_ble_tracker::ESPBTUUID::from_uint16(0x1A00)) {
-            ESP_LOGI(TAG, "Found Eqiva device (MAC: %s) (UUID): %s  (Name): %s", device.address_str().c_str(), it.uuid.to_string().c_str(), device.get_name().c_str());
+            ESP_LOGI(TAG, "Found Eqiva device (MAC: %s) (UUID): %s  (Name): %s", device.address_str().c_str(), it.uuid.to_str().c_str(), device.get_name().c_str());
             return true;
         }
     }

--- a/components/eqiva_key_ble/__init__.py
+++ b/components/eqiva_key_ble/__init__.py
@@ -68,6 +68,7 @@ async def to_code(config):
             cv.Required(CONF_LOCK_TURNS): cv.templatable(cv.int_range(min=1, max=4)),
         }
     ),
+    synchronous=False,
 )
 async def eqiva_key_ble_settings_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -91,6 +92,7 @@ async def eqiva_key_ble_settings_to_code(config, action_id, template_arg, args):
             cv.Required(CONF_USER_KEY): cv.templatable(cv.string),
         }
     ),
+    synchronous=False,
 )
 async def eqiva_key_ble_connect_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -111,6 +113,7 @@ async def eqiva_key_ble_connect_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(EqivaKeyBle),
         }
     ),
+    synchronous=False,
 )
 async def eqiva_key_ble_disconnect_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -127,6 +130,7 @@ async def eqiva_key_ble_disconnect_to_code(config, action_id, template_arg, args
             cv.Required(CONF_MAC_ADDRESS): cv.templatable(cv.string),
         }
     ),
+    synchronous=False,
 )
 async def eqiva_key_ble_pair_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -145,6 +149,7 @@ async def eqiva_key_ble_pair_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(EqivaKeyBle),
         }
     ),
+    synchronous=False,
 )
 async def eqiva_key_ble_lock_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -160,6 +165,7 @@ async def eqiva_key_ble_lock_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(EqivaKeyBle),
         }
     ),
+    synchronous=False,
 )
 async def eqiva_key_ble_unlock_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -174,6 +180,7 @@ async def eqiva_key_ble_unlock_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(EqivaKeyBle),
         }
     ),
+    synchronous=False,
 )
 async def eqiva_key_ble_open_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -188,8 +195,14 @@ async def eqiva_key_ble_open_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(EqivaKeyBle),
         }
     ),
+    synchronous=False,
 )
 async def eqiva_key_ble_status_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
+```
+
+**To deploy this without forking the repo**, use ESPHome's `local` source override. Save the patched file to your HA config folder at:
+```
+/config/esphome/components/eqiva_key_ble/__init__.py

--- a/components/eqiva_key_ble/__init__.py
+++ b/components/eqiva_key_ble/__init__.py
@@ -201,8 +201,3 @@ async def eqiva_key_ble_status_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
-```
-
-**To deploy this without forking the repo**, use ESPHome's `local` source override. Save the patched file to your HA config folder at:
-```
-/config/esphome/components/eqiva_key_ble/__init__.py

--- a/components/eqiva_key_ble/eqiva_key_ble.h
+++ b/components/eqiva_key_ble/eqiva_key_ble.h
@@ -39,11 +39,7 @@ class EqivaKeyBle : public BLEClientBase {
     bool requestPair;
 
     unsigned long getTime() {
-        time_t now;
-        struct tm timeinfo;
-        localtime_r(&now, &timeinfo);
-        time(&now);
-        return now;
+        return millis() / 1000;
     }
     std::string getClientState() {
         std::string client_state;


### PR DESCRIPTION
## Fix compatibility with ESPHome 2026.3.0

This PR fixes three breaking issues introduced by ESPHome 2026.3.0 that cause the component to crash or fail to compile.

### 1. `getTime()` crash on lock/unlock (`eqiva_key_ble.h`)

`localtime_r` was being called with an uninitialized `time_t now` variable — the `time(&now)` call that populates it came after. This was always a latent bug but recent ESP-IDF versions crash on it. Since `getTime()` is only used for a 3-second send timeout, replaced with `millis() / 1000` which is always valid and has no SNTP dependency.

### 2. Missing `synchronous=` parameter on all `register_action` calls (`eqiva_key_ble/__init__.py`)

ESPHome 2026.3.0 made the `synchronous=` parameter required for `register_action()`. Without it the component fails with a warning and actions do not work correctly. Added `synchronous=False` to all eight action registrations.

### 3. Deprecated `yield`-based coroutine in `eqiva_ble/__init__.py`

`to_code` was using the old `yield` coroutine pattern which is no longer supported. Converted to `async/await`.