### PR TITLE
Improvement of Connection Latency

### DIFF
--- a/components/eqiva_key_ble/__init__.py
+++ b/components/eqiva_key_ble/__init__.py
@@ -31,6 +31,7 @@ EqivaPair = eqiva_key_ble_ns.class_("EqivaPair", automation.Action)
 EqivaConnect = eqiva_key_ble_ns.class_("EqivaConnect", automation.Action)
 EqivaDisconnect = eqiva_key_ble_ns.class_("EqivaDisconnect", automation.Action)
 EqivaSettings = eqiva_key_ble_ns.class_("EqivaSettings", automation.Action)
+EqivaRunTest = eqiva_key_ble_ns.class_("EqivaRunTest", automation.Action)
 
 CONFIG_SCHEMA = (
     cv.Schema(
@@ -39,6 +40,8 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_MAC_ADDRESS): cv.templatable(cv.mac_address),
             cv.Optional(CONF_USER_ID, default=255): cv.one_of(0, 1, 2, 3, 4, 5, 6, 7, 255),
             cv.Optional(CONF_USER_KEY, default=""): cv.string,
+            cv.Optional("disconnect_timeout", default="0s"): cv.positive_time_period_milliseconds,
+            cv.Optional("status_update_interval", default="2h"): cv.positive_time_period_milliseconds,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -54,7 +57,8 @@ async def to_code(config):
         cg.add(var.set_address(mac_address.as_hex))
     cg.add(var.set_user_id(config[CONF_USER_ID]))
     cg.add(var.set_user_key(config[CONF_USER_KEY]))
-    cg.add(var.set_auto_connect(True))
+    cg.add(var.set_disconnect_timeout(config["disconnect_timeout"]))
+    cg.add(var.set_status_update_interval(config["status_update_interval"]))
 
 
 @automation.register_action(
@@ -198,6 +202,21 @@ async def eqiva_key_ble_open_to_code(config, action_id, template_arg, args):
     synchronous=False,
 )
 async def eqiva_key_ble_status_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var
+
+@automation.register_action(
+    "eqiva_key_ble.run_test",
+    EqivaRunTest,
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(EqivaKeyBle),
+        }
+    ),
+    synchronous=False,
+)
+async def eqiva_key_ble_run_test_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var

--- a/components/eqiva_key_ble/eqiva_key_ble.cpp
+++ b/components/eqiva_key_ble/eqiva_key_ble.cpp
@@ -5,6 +5,8 @@
 #include "eQ3_message.h"
 #include <sstream>
 #include "esp_random.h"
+#include "esphome/components/esp32_ble_client/ble_characteristic.h"
+#include "esphome/components/esp32_ble_client/ble_service.h"
 
 #ifdef USE_ESP32
 
@@ -28,36 +30,341 @@ bool EqivaKeyBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t 
                                       
   this->mac_address_sensor_->publish_state(this->address_str());
 
-  if (!BLEClientBase::gattc_event_handler(event, esp_gattc_if, param))
-    return false;
+  // Bypassing MTU negotiation for Eqiva Lock on CONNECT event
+  if (event == ESP_GATTC_CONNECT_EVT) {
+    if (this->check_addr(param->connect.remote_bda)) {
+      this->conn_id_ = param->connect.conn_id;
+      this->set_state(espbt::ClientState::CONNECTING);
+      ESP_LOGD(TAG, "Bypassing MTU request for Eqiva Lock on CONNECT event.");
+      return true; // Prevents BLEClientBase from sending MTU request
+    }
+  }
 
-  this->lock_ble_state_sensor_->publish_state(getClientState());
+  // Intercept ESP_GATTC_OPEN_EVT to read GATT services and characteristics from local cache
+  if (event == ESP_GATTC_OPEN_EVT) {
+    if (this->check_addr(param->open.remote_bda)) {
+      if (this->cached_write_handle_ != 0 && this->cached_read_handle_ != 0 && 
+          (param->open.status == ESP_GATT_OK || param->open.status == ESP_GATT_ALREADY_OPEN)) {
+        ESP_LOGI(TAG, "Found Eqiva Lock characteristics in class cache (Write: 0x%04x, Read: 0x%04x). Bypassing OTA service search!", 
+                 this->cached_write_handle_, this->cached_read_handle_);
+        
+        // Cache hit! Update our conn_id_ and state to match a successful connection open
+        this->conn_id_ = param->open.conn_id;
+        this->set_state(espbt::ClientState::CONNECTED);
 
-  switch (event) {
-    case ESP_GATTC_SEARCH_CMPL_EVT: {
-      if (this->state() == espbt::ClientState::ESTABLISHED) {
+        if (this->testing_) {
+          this->test_connect_time_ = millis() - this->test_start_time_;
+          ESP_LOGI(TAG, "ESP Eqiva Test: BLE physically connected (GATT Cached). Time: %lu ms", this->test_connect_time_);
+        }
+
+        if (this->manually_allocated_chars_) {
+          if (write != nullptr) {
+            if (write->service != nullptr) delete write->service;
+            delete write;
+          }
+          if (read != nullptr) {
+            if (read->service != nullptr) delete read->service;
+            delete read;
+          }
+          this->manually_allocated_chars_ = false;
+        }
+
+        write = new BLECharacteristic();
+        write->handle = this->cached_write_handle_;
+        write->uuid = esp32_ble_tracker::ESPBTUUID::from_raw("3141dd40-15db-11e6-a24b-0002a5d5c51b");
+        write->service = new BLEService();
+        write->service->client = this;
+
+        read = new BLECharacteristic();
+        read->handle = this->cached_read_handle_;
+        read->uuid = esp32_ble_tracker::ESPBTUUID::from_raw("359d4820-15db-11e6-82bd-0002a5d5c51b");
+        read->service = new BLEService();
+        read->service->client = this;
+
+        this->manually_allocated_chars_ = true;
+
+        esp_err_t errRc = ::esp_ble_gattc_register_for_notify(
+            this->gattc_if_,
+            this->remote_bda_,
+            read->handle
+        );
+
+        this->set_state(espbt::ClientState::ESTABLISHED);
         clientState.remote_session_nonce.clear();
         clientState.local_session_nonce.clear();
-        write = this->get_characteristic(esp32_ble_tracker::ESPBTUUID::from_raw("58e06900-15d8-11e6-b737-0002a5d5c51b"), esp32_ble_tracker::ESPBTUUID::from_raw("3141dd40-15db-11e6-a24b-0002a5d5c51b"));
-        read = this->get_characteristic(esp32_ble_tracker::ESPBTUUID::from_raw("58e06900-15d8-11e6-b737-0002a5d5c51b"), esp32_ble_tracker::ESPBTUUID::from_raw("359d4820-15db-11e6-82bd-0002a5d5c51b"));
-        esp_err_t errRc = ::esp_ble_gattc_register_for_notify(
-          this->gattc_if_,
-          this->remote_bda_,
-          read->handle
-        );
 
         init();
         if (currentMsg == NULL && requestPair == false && clientState.user_key.length() > 0 && clientState.user_id < 255) {
           auto * msg = new eQ3Message::StatusRequestMessage;
           sendMessage(msg, false);
         }
-  
+        return true; // Bypasses BLEClientBase::gattc_event_handler for OPEN_EVT
+      }
+
+      ESP_LOGD(TAG, "Connection open. Querying local GATT cache for Eqiva Lock...");
+
+      // 1. Query Service UUID "58e06900-15d8-11e6-b737-0002a5d5c51b"
+      esp_bt_uuid_t svc_uuid;
+      svc_uuid.len = ESP_UUID_LEN_128;
+      uint8_t svc_uuid_bytes[16] = {0x1b, 0xc5, 0xd5, 0xa5, 0x02, 0x00, 0x37, 0xb7, 0xe6, 0x11, 0xd8, 0x15, 0x00, 0x69, 0xe0, 0x58};
+      memcpy(svc_uuid.uuid.uuid128, svc_uuid_bytes, 16);
+
+      uint16_t count = 0;
+      esp_gatt_status_t status = esp_ble_gattc_get_service(
+          this->gattc_if_,
+          param->open.conn_id,
+          &svc_uuid,
+          nullptr,
+          &count,
+          0
+      );
+
+      uint16_t write_handle = 0;
+      uint16_t read_handle = 0;
+
+      if (status == ESP_GATT_OK && count > 0) {
+        esp_gattc_service_elem_t *result = (esp_gattc_service_elem_t *) malloc(sizeof(esp_gattc_service_elem_t) * count);
+        if (result != nullptr) {
+          status = esp_ble_gattc_get_service(
+              this->gattc_if_,
+              param->open.conn_id,
+              &svc_uuid,
+              result,
+              &count,
+              0
+          );
+          if (status == ESP_GATT_OK) {
+            uint16_t start_handle = result[0].start_handle;
+            uint16_t end_handle = result[0].end_handle;
+
+            // 2. Query Write Characteristic UUID "3141dd40-15db-11e6-a24b-0002a5d5c51b"
+            esp_bt_uuid_t write_uuid;
+            write_uuid.len = ESP_UUID_LEN_128;
+            uint8_t write_uuid_bytes[16] = {0x1b, 0xc5, 0xd5, 0xa5, 0x02, 0x00, 0x4b, 0xa2, 0xe6, 0x11, 0xdb, 0x15, 0x40, 0xdd, 0x41, 0x31};
+            memcpy(write_uuid.uuid.uuid128, write_uuid_bytes, 16);
+
+            uint16_t char_count = 0;
+            status = esp_ble_gattc_get_char_by_uuid(
+                this->gattc_if_,
+                param->open.conn_id,
+                start_handle,
+                end_handle,
+                write_uuid,
+                nullptr,
+                &char_count
+            );
+            if (status == ESP_GATT_OK && char_count > 0) {
+              esp_gattc_char_elem_t *char_result = (esp_gattc_char_elem_t *) malloc(sizeof(esp_gattc_char_elem_t) * char_count);
+              if (char_result != nullptr) {
+                status = esp_ble_gattc_get_char_by_uuid(
+                    this->gattc_if_,
+                    param->open.conn_id,
+                    start_handle,
+                    end_handle,
+                    write_uuid,
+                    char_result,
+                    &char_count
+                );
+                if (status == ESP_GATT_OK) {
+                  write_handle = char_result[0].char_handle;
+                }
+                free(char_result);
+              }
+            }
+
+            // 3. Query Read Characteristic UUID "359d4820-15db-11e6-82bd-0002a5d5c51b"
+            esp_bt_uuid_t read_uuid;
+            read_uuid.len = ESP_UUID_LEN_128;
+            uint8_t read_uuid_bytes[16] = {0x1b, 0xc5, 0xd5, 0xa5, 0x02, 0x00, 0xbd, 0x82, 0xe6, 0x11, 0xdb, 0x15, 0x20, 0x48, 0x9d, 0x35};
+            memcpy(read_uuid.uuid.uuid128, read_uuid_bytes, 16);
+
+            char_count = 0;
+            status = esp_ble_gattc_get_char_by_uuid(
+                this->gattc_if_,
+                param->open.conn_id,
+                start_handle,
+                end_handle,
+                read_uuid,
+                nullptr,
+                &char_count
+            );
+            if (status == ESP_GATT_OK && char_count > 0) {
+              esp_gattc_char_elem_t *char_result = (esp_gattc_char_elem_t *) malloc(sizeof(esp_gattc_char_elem_t) * char_count);
+              if (char_result != nullptr) {
+                status = esp_ble_gattc_get_char_by_uuid(
+                    this->gattc_if_,
+                    param->open.conn_id,
+                    start_handle,
+                    end_handle,
+                    read_uuid,
+                    char_result,
+                    &char_count
+                );
+                if (status == ESP_GATT_OK) {
+                  read_handle = char_result[0].char_handle;
+                }
+                free(char_result);
+              }
+            }
+          }
+          free(result);
+        }
+      }
+
+      if (write_handle != 0 && read_handle != 0) {
+        ESP_LOGI(TAG, "Found Eqiva Lock characteristics in local cache (Write: 0x%04x, Read: 0x%04x). Bypassing OTA service search!", write_handle, read_handle);
+        
+        // Cache hit! Update our conn_id_ and state to match a successful connection open
+        this->conn_id_ = param->open.conn_id;
+        this->set_state(espbt::ClientState::CONNECTED);
+
+        if (this->testing_) {
+          this->test_connect_time_ = millis() - this->test_start_time_;
+          ESP_LOGI(TAG, "ESP Eqiva Test: BLE physically connected (GATT Cached). Time: %lu ms", this->test_connect_time_);
+        }
+
+        if (write != nullptr) {
+          if (write->service != nullptr) delete write->service;
+          delete write;
+        }
+        if (read != nullptr) {
+          if (read->service != nullptr) delete read->service;
+          delete read;
+        }
+
+        write = new BLECharacteristic();
+        write->handle = write_handle;
+        write->uuid = esp32_ble_tracker::ESPBTUUID::from_raw("3141dd40-15db-11e6-a24b-0002a5d5c51b");
+        write->service = new BLEService();
+        write->service->client = this;
+
+        read = new BLECharacteristic();
+        read->handle = read_handle;
+        read->uuid = esp32_ble_tracker::ESPBTUUID::from_raw("359d4820-15db-11e6-82bd-0002a5d5c51b");
+        read->service = new BLEService();
+        read->service->client = this;
+
+        esp_err_t errRc = ::esp_ble_gattc_register_for_notify(
+            this->gattc_if_,
+            this->remote_bda_,
+            read->handle
+        );
+
+        this->set_state(espbt::ClientState::ESTABLISHED);
+        clientState.remote_session_nonce.clear();
+        clientState.local_session_nonce.clear();
+
+        init();
+        if (currentMsg == NULL && requestPair == false && clientState.user_key.length() > 0 && clientState.user_id < 255) {
+          auto * msg = new eQ3Message::StatusRequestMessage;
+          sendMessage(msg, false);
+        }
+        return true; // Bypasses BLEClientBase::gattc_event_handler for OPEN_EVT
+      } else {
+        ESP_LOGD(TAG, "Eqiva Lock characteristics not found in local cache. Running standard service search...");
+        
+        // Debug local cache services
+        uint16_t all_count = 0;
+        esp_gatt_status_t all_status = esp_ble_gattc_get_service(
+            this->gattc_if_,
+            param->open.conn_id,
+            nullptr,
+            nullptr,
+            &all_count,
+            0
+        );
+        ESP_LOGD(TAG, "GATT Cache all services count: %d, status: %d", all_count, all_status);
+        if (all_status == ESP_GATT_OK && all_count > 0) {
+          esp_gattc_service_elem_t *all_result = (esp_gattc_service_elem_t *) malloc(sizeof(esp_gattc_service_elem_t) * all_count);
+          if (all_result != nullptr) {
+            esp_ble_gattc_get_service(
+                this->gattc_if_,
+                param->open.conn_id,
+                nullptr,
+                all_result,
+                &all_count,
+                0
+            );
+            for (int i = 0; i < all_count; i++) {
+              auto uuid = esp32_ble_tracker::ESPBTUUID::from_uuid(all_result[i].uuid);
+              char uuid_str[esp32_ble_tracker::UUID_STR_LEN];
+              uuid.to_str(uuid_str);
+              ESP_LOGD(TAG, "  Cached service [%d]: %s (start: 0x%04x, end: 0x%04x)", 
+                       i, uuid_str, all_result[i].start_handle, all_result[i].end_handle);
+            }
+            free(all_result);
+          }
+        }
+      }
+    }
+  }
+
+  if (!BLEClientBase::gattc_event_handler(event, esp_gattc_if, param))
+    return false;
+
+  this->lock_ble_state_sensor_->publish_state(getClientState());
+
+  switch (event) {
+    case ESP_GATTC_OPEN_EVT: {
+      if (this->testing_) {
+        this->test_connect_time_ = millis() - this->test_start_time_;
+        ESP_LOGI(TAG, "ESP Eqiva Test: BLE physically connected. Time: %lu ms", this->test_connect_time_);
       }
       break;
     }
-    case ESP_GATTC_DISCONNECT_EVT: {
-      ESP_LOGD(TAG, "ESP_GATTC_DISCONNECT_EVT");
-    
+    case ESP_GATTC_SEARCH_CMPL_EVT: {
+      if (this->state() == espbt::ClientState::ESTABLISHED) {
+        clientState.remote_session_nonce.clear();
+        clientState.local_session_nonce.clear();
+        write = this->get_characteristic(esp32_ble_tracker::ESPBTUUID::from_raw("58e06900-15d8-11e6-b737-0002a5d5c51b"), esp32_ble_tracker::ESPBTUUID::from_raw("3141dd40-15db-11e6-a24b-0002a5d5c51b"));
+        read = this->get_characteristic(esp32_ble_tracker::ESPBTUUID::from_raw("58e06900-15d8-11e6-b737-0002a5d5c51b"), esp32_ble_tracker::ESPBTUUID::from_raw("359d4820-15db-11e6-82bd-0002a5d5c51b"));
+        
+        if (write != nullptr && read != nullptr) {
+          this->cached_write_handle_ = write->handle;
+          this->cached_read_handle_ = read->handle;
+          ESP_LOGI(TAG, "Cached handles from discovery: Write: 0x%04x, Read: 0x%04x", this->cached_write_handle_, this->cached_read_handle_);
+
+          esp_err_t errRc = ::esp_ble_gattc_register_for_notify(
+            this->gattc_if_,
+            this->remote_bda_,
+            read->handle
+          );
+
+          init();
+          if (currentMsg == NULL && requestPair == false && clientState.user_key.length() > 0 && clientState.user_id < 255) {
+            auto * msg = new eQ3Message::StatusRequestMessage;
+            sendMessage(msg, false);
+          }
+        } else {
+          ESP_LOGE(TAG, "Failed to find write or read characteristic during service discovery!");
+        }
+      }
+      break;
+    }
+    case ESP_GATTC_DISCONNECT_EVT:
+    case ESP_GATTC_CLOSE_EVT: {
+      ESP_LOGD(TAG, "ESP_GATTC_DISCONNECT_EVT / ESP_GATTC_CLOSE_EVT");
+#ifdef USE_ESP32
+      if (!this->handshake_completed_ && this->cached_write_handle_ != 0) {
+        ESP_LOGW(TAG, "Connection lost before handshake completed. Invalidating GATT cache handles!");
+        this->cached_write_handle_ = 0;
+        this->cached_read_handle_ = 0;
+      }
+#endif
+      if (this->manually_allocated_chars_) {
+        if (write != nullptr) {
+          if (write->service != nullptr) delete write->service;
+          delete write;
+          write = nullptr;
+        }
+        if (read != nullptr) {
+          if (read->service != nullptr) delete read->service;
+          delete read;
+          read = nullptr;
+        }
+        this->manually_allocated_chars_ = false;
+        ESP_LOGD(TAG, "Manually allocated characteristics cleaned up on disconnect/close.");
+      }
       break;
     }
     case ESP_GATTC_SEARCH_RES_EVT: {
@@ -173,7 +480,14 @@ bool EqivaKeyBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t 
               this->user_key_sensor_->publish_state(string_to_hex(clientState.user_key).c_str());
               this->user_id_sensor_->publish_state(std::to_string(user_id));
   
+              this->handshake_completed_ = true;
+              this->last_activity_time_ = millis();
+
               sendingNonce = false;
+              if (this->testing_) {
+                this->test_handshake_time_ = millis() - this->test_start_time_;
+                ESP_LOGI(TAG, "ESP Eqiva Test: Handshake nonce exchanged. Time: %lu ms", this->test_handshake_time_);
+              }
               if (currentMsg != NULL) {
                 sendMessage(currentMsg, false);
                 currentMsg = NULL;
@@ -212,11 +526,54 @@ bool EqivaKeyBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t 
                   break;
                 }
               }
+              this->last_status_update_time_ = millis();
               this->lock_status_sensor_->publish_state(lockStatus);
               this->low_battery_sensor_->publish_state(message.isBatteryLow() ? "true" : "false");
 
               ESP_LOGD(TAG, "# Lock state: %d", message.getLockStatus());
               ESP_LOGD(TAG, "# Battery low: %s", message.isBatteryLow() ? "true" : "false");
+
+              if (this->testing_) {
+                int status_val = message.getLockStatus();
+                if (this->test_target_state_ == "") {
+                  // Initial status check
+                  if (status_val == 3) { // LOCKED
+                    ESP_LOGI(TAG, "ESP Eqiva Test: Initial status: LOCKED. Sending UNLOCK command...");
+                    this->test_target_state_ = "UNLOCKED";
+                    this->sendCommand(UNLOCK);
+                  } else if (status_val == 2) { // UNLOCKED
+                    ESP_LOGI(TAG, "ESP Eqiva Test: Initial status: UNLOCKED. Sending LOCK command...");
+                    this->test_target_state_ = "LOCKED";
+                    this->sendCommand(LOCK);
+                  } else {
+                    ESP_LOGE(TAG, "ESP Eqiva Test: Initial status is UNKNOWN/MOVING/OPENED (%d). Aborting test.", status_val);
+                    this->testing_ = false;
+                    this->disconnect();
+                  }
+                } else if (status_val == 1) { // MOVING
+                  if (this->test_motor_start_time_ == 0) {
+                    this->test_motor_start_time_ = millis() - this->test_start_time_;
+                    ESP_LOGI(TAG, "ESP Eqiva Test: Motor started turning! Time: %lu ms", this->test_motor_start_time_);
+                  }
+                } else {
+                  std::string state_str = "";
+                  if (status_val == 3) state_str = "LOCKED";
+                  else if (status_val == 2) state_str = "UNLOCKED";
+                  
+                  if (state_str == this->test_target_state_) {
+                    unsigned long total_time = millis() - this->test_start_time_;
+                    ESP_LOGI(TAG, "ESP Eqiva Test: Target state %s reached!", state_str.c_str());
+                    ESP_LOGI(TAG, "=== LATENCY TEST SUMMARY ===");
+                    ESP_LOGI(TAG, "Connect:     %lu ms", this->test_connect_time_);
+                    ESP_LOGI(TAG, "Handshake:   %lu ms (ab connect: %lu ms)", this->test_handshake_time_, this->test_handshake_time_ - this->test_connect_time_);
+                    ESP_LOGI(TAG, "Motor start: %lu ms", this->test_motor_start_time_);
+                    ESP_LOGI(TAG, "Total cycle: %lu ms", total_time);
+                    ESP_LOGI(TAG, "============================");
+                    this->testing_ = false;
+                    this->disconnect();
+                  }
+                }
+              }
               break;
           }
 
@@ -323,6 +680,7 @@ void EqivaKeyBle::sendNonce() {
 }
 
 bool EqivaKeyBle::sendMessage(eQ3Message::Message *msg, bool nonce) {
+    this->last_activity_time_ = millis();
     if (((sendingNonce == false && clientState.remote_session_nonce.length() > 0) || nonce) && this->state() == espbt::ClientState::ESTABLISHED) {
       ESP_LOGD(TAG, "Start send message");
       std::string data;
@@ -389,6 +747,10 @@ bool EqivaKeyBle::sendMessage(eQ3Message::Message *msg, bool nonce) {
         }
         currentMsg = msg;
       }
+      if (this->state() == espbt::ClientState::IDLE) {
+        ESP_LOGI(TAG, "Triggering connection to send message.");
+        this->connect();
+      }
       return false;
     }
 }
@@ -407,8 +769,80 @@ void EqivaKeyBle::sendFragment() {
     write->write_value((uint8_t *) (data.c_str()), 16, ESP_GATT_WRITE_TYPE_RSP);
 }
 
+void EqivaKeyBle::runTest() {
+    ESP_LOGI(TAG, "ESP Eqiva Test: Starting automated latency test run...");
+    if (this->address_ == 0 || this->address_ == 1) {
+        ESP_LOGE(TAG, "ESP Eqiva Test: Error - No valid MAC address configured.");
+        return;
+    }
+    this->testing_ = true;
+    this->test_start_time_ = millis();
+    this->test_connect_time_ = 0;
+    this->test_handshake_time_ = 0;
+    this->test_motor_start_time_ = 0;
+    this->test_target_state_ = "";
+
+    if (this->state() != espbt::ClientState::IDLE) {
+        ESP_LOGD(TAG, "ESP Eqiva Test: Reconnecting to restart test...");
+        this->disconnect();
+    }
+    this->connect();
+}
+
+void EqivaKeyBle::setup() {
+  BLEClientBase::setup();
+  this->set_auto_connect(this->disconnect_timeout_ == 0);
+  this->last_status_update_time_ = millis();
+}
+
+#ifdef USE_ESP32_BLE_DEVICE
+bool EqivaKeyBle::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
+  if (device.address_uint64() == this->address_) {
+    this->remote_addr_type_ = device.get_address_type();
+  }
+  return BLEClientBase::parse_device(device);
+}
+#endif
+
+void EqivaKeyBle::connect() {
+  this->handshake_completed_ = false;
+  this->last_activity_time_ = millis();
+  BLEClientBase::connect();
+}
+
+void EqivaKeyBle::disconnect() {
+  BLEClientBase::disconnect();
+}
+
+void EqivaKeyBle::loop() {
+  uint32_t now = millis();
+  if (this->state() == espbt::ClientState::ESTABLISHED) {
+    if (this->disconnect_timeout_ > 0) {
+      if (now - this->last_activity_time_ > this->disconnect_timeout_) {
+        ESP_LOGI(TAG, "Connection idle for %u ms. Disconnecting to save battery.", this->disconnect_timeout_);
+        this->disconnect();
+      }
+    } else {
+      // Continuous connection mode: refresh status every 4 minutes (240000 ms)
+      if (now - this->last_status_update_time_ > 240000) {
+        ESP_LOGI(TAG, "Continuous connection status update interval reached. Requesting status...");
+        this->last_status_update_time_ = now;
+        this->sendCommand(REQUEST_STATUS);
+      }
+    }
+  } else if (this->state() == espbt::ClientState::IDLE) {
+    if (this->disconnect_timeout_ > 0 && this->status_update_interval_ > 0) {
+      if (now - this->last_status_update_time_ > this->status_update_interval_) {
+        ESP_LOGI(TAG, "Periodic status update interval reached. Connecting to retrieve status...");
+        this->last_status_update_time_ = now;
+        this->connect();
+      }
+    }
+  }
+}
 
 }  // namespace eqiva_key_ble
 }  // namespace esphome
 
 #endif
+

--- a/components/eqiva_key_ble/eqiva_key_ble.h
+++ b/components/eqiva_key_ble/eqiva_key_ble.h
@@ -37,6 +37,14 @@ class EqivaKeyBle : public BLEClientBase {
     unsigned long sending;
     eQ3Message::Message *currentMsg;
     bool requestPair;
+    uint16_t cached_write_handle_{0};
+    uint16_t cached_read_handle_{0};
+    bool manually_allocated_chars_{false};
+    uint32_t last_activity_time_{0};
+    bool handshake_completed_{false};
+    uint32_t disconnect_timeout_{0};
+    uint32_t status_update_interval_{7200000};
+    uint32_t last_status_update_time_{0};
 
     unsigned long getTime() {
         return millis() / 1000;
@@ -77,6 +85,15 @@ class EqivaKeyBle : public BLEClientBase {
     }
     public:
         ClientState clientState;
+        void setup() override;
+#ifdef USE_ESP32_BLE_DEVICE
+        bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
+#endif
+        void set_disconnect_timeout(uint32_t ms) { this->disconnect_timeout_ = ms; }
+        void set_status_update_interval(uint32_t ms) { this->status_update_interval_ = ms; }
+        void connect();
+        void disconnect();
+        void loop() override;
         void startPair();
         void applySettings();
         void sendCommand(CommandType command);
@@ -114,6 +131,13 @@ class EqivaKeyBle : public BLEClientBase {
         void dump_config() override;
         bool gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                                 esp_ble_gattc_cb_param_t *param) override;
+        void runTest();
+        bool testing_{false};
+        unsigned long test_start_time_{0};
+        unsigned long test_connect_time_{0};
+        unsigned long test_handshake_time_{0};
+        unsigned long test_motor_start_time_{0};
+        std::string test_target_state_{""};
 
     protected: 
         text_sensor::TextSensor *lock_ble_state_sensor_{nullptr};                
@@ -161,8 +185,8 @@ class EqivaConnect : public Action<Ts...>, public Parented<EqivaKeyBle> {
             this->parent_->set_user_id(user_id);
             this->parent_->set_user_key(user_key);
             this->parent_->set_address(string_to_mac(mac_address));
+            this->parent_->connect();
             ESP_LOGD("ESP Eqiva", " Address: %s, %s", this->parent_->address_str(), mac_address.c_str());
-
         }
 };
 
@@ -213,6 +237,12 @@ template<typename... Ts>
 class EqivaStatus : public Action<Ts...>, public Parented<EqivaKeyBle> {
  public:
   void play(const Ts &...x) { this->parent_->sendCommand(REQUEST_STATUS); }
+};
+
+template<typename... Ts>
+class EqivaRunTest : public Action<Ts...>, public Parented<EqivaKeyBle> {
+ public:
+  void play(const Ts &...x) { this->parent_->runTest(); }
 };
 
 

--- a/example.yaml
+++ b/example.yaml
@@ -18,7 +18,7 @@ logger:
 # Enable Home Assistant API
 api:
   encryption:
-    key: "44535345342523452354235dfasgfgdfatre="
+    key: "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI="
         
 web_server:
   port: 80
@@ -56,7 +56,7 @@ wifi:
     ssid: "Esphome-Eqiva-Lock"
     password: "12345678"
   # Activate scan only after wifi connect, see https://github.com/esphome/issues/issues/2941#issuecomment-1842369092
-    on_connect:
+  on_connect:
     - esp32_ble_tracker.start_scan:
         continuous: true
     - eqiva_key_ble.connect:
@@ -71,7 +71,9 @@ wifi:
 captive_portal:
 
 external_components:
-  - source: github://digaus/esphome-components-eqiva
+  - source:
+      type: local
+      path: components
 
 esp32_ble_tracker:
   id: ble_tracker
@@ -84,17 +86,11 @@ eqiva_ble:
 
 eqiva_key_ble:
   id: key_ble
-
-time:
-  - platform: sntp
-    id: sntptime
-    # ...
-    on_time:
-      # Every 4 minutes
-      - seconds: 0
-        minutes: /4
-        then:
-          - eqiva_key_ble.status:
+  # If disconnect_timeout is set (e.g. 10s), the ESP32 disconnects from the lock after that period of inactivity
+  # to save lock battery. If not set (default 0s), the connection stays active.
+  disconnect_timeout: 10s
+  # When disconnect_timeout is set, define how often to reconnect to query status (default 2h)
+  status_update_interval: 2h
 
 
 button:


### PR DESCRIPTION
In reference to https://github.com/digaus/esphome-components-eqiva/issues/47

# PR Description: Latency and Battery Optimizations for Eqiva BLE Lock Component

This PR introduces several significant performance and stability optimizations to the custom ESPHome component `eqiva_key_ble` for the Eqiva Bluetooth Smart Lock.

By optimizing the BLE connection pipeline (bypassing MTU exchange, implementing local GATT caching, initiating direct connection, and introducing an idle-timeout hysteresis with automatic cache recovery), we reduced the total latency from triggering the command in Home Assistant to the physical motor starting from **~3.14 seconds to ~1.97 seconds (~37% faster)**.

---

##  Key Improvements & Features

### 1. MTU Negotiation Bypass
* **Action:** Bypasses the MTU exchange request on BLE connection establishment.
* **Benefit:** Prevents connection timeouts with the Eqiva lock (which doesn't support MTU negotiation) and saves ~200 ms.

### 2. Class-Level & NVS GATT Handle Caching
* **Action:** Stores the write and read characteristic handles locally in the ESP32 RAM (and persists them in NVS flash). On subsequent connection attempts, it bypasses the over-the-air (OTA) service discovery phase completely and starts communicating immediately.
* **Benefit:** Saves ~200 ms of radio search time.

### 3. Direct-Connect Scan Bypass
* **Action:** Bypasses ESPHome's active BLE scanner wait time by immediately triggering the `connect()` sequence to the target MAC address.
* **Benefit:** Reduces idle connection establishment time by ~216 ms.

### 4. 10-Second Idle Timeout Hysteresis (Hold Connection)
* **Action:** Instead of disconnecting immediately, the BLE connection is held open for **10 seconds** after the last activity.
* **Benefit:** If multiple commands are triggered in sequence (e.g., *Unlock* followed immediately by *Open*), the subsequent command is executed **instantly (in milliseconds)**. If no activity occurs for 10 seconds, the connection is closed to preserve the lock's battery (which would otherwise drain within a month).

### 5. Automatic GATT-Cache Recovery Fallback
* **Action:** If a cached connection attempt fails before the cryptographic handshake (`Case 0x03` nonce exchange) completes, the component automatically invalidates and clears the cached handles.
* **Benefit:** Prevents deadlock reconnection loops if the lock is reset or firmware handles change. The next connection attempt will automatically fall back to a fresh OTA service discovery to rebuild the cache, requiring no manual re-flashes or reboots.

---

##  Performance Timings Comparison

Below is a chronological breakdown of the latency optimizations compared to the benchmarks:

| Phase / Metric | 1. ESPHome Stock (Vanilla) [1] | 2. Standalone NimBLE (Ideal-Benchmark) | 3. Python keyble (BlueZ Benchmark) [2] | 4. Step 1: MTU Bypass & Auto-Disconnect | 5. Step 2: Class GATT Caching | 6. Step 3: Direct Connect (Final Optimization) | 7. Step 4: disconnect_wifi (Optional) |
| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| **Physical Connect** | ~2735 ms | ~1191 ms | ~2000 ms | **~1834 ms** | **~1820 ms** | **~1701 ms** | **~1825 ms** |
| **Handshake / Service Search** | ~104 ms | ~45 ms | ~300 ms | **~203 ms** (OTA) | **~7 ms** (Cached Handles) | **~10 ms** (Cached Handles) | **~307 ms** (Nonce exchanged) |
| **Motor Start (from Connect)** | ~404 ms | ~196 ms | ~500 ms | **~484 ms** | **~371 ms** | **~264 ms** (Instant send) | **~256 ms** (Befehl gesendet) |
| **Total Time to Motor Start** | **~3138 ms** | **~1387 ms** | **~2500 ms** | **~2318 ms** | **~2191 ms** | **~1975 ms** (Under 2s!) | **~2388 ms** (Max stability) |
| **BLE Stack** | Bluedroid | **NimBLE** (Optimized) | **BlueZ** (Linux) | Bluedroid | Bluedroid | Bluedroid | Bluedroid |
| **Wi-Fi / Network Activity** | Active (HA API, Web) | **Disabled** (No Wi-Fi overhead) | Active (Host Wi-Fi) | Active (HA API, Web) | Active (HA API, Web) | Active (HA API, Web) | **Disabled** (during connect) |
| **Scanning Duty Cycle** | 50% (Bluedroid default) | **100%** (NimBLE default) | Managed by BlueZ | 50% (Bluedroid default) | 50% (Bluedroid default) | **100%** (Direct Connect) | **100%** (Wi-Fi stopped) |
| **Task Jitter & Concurrency** | High (mDNS, API, Web) | **Minimal** (Pure BLE firmware) | Medium (Linux OS scheduler) | High (mDNS, API, Web) | High (mDNS, API, Web) | High (mDNS, API, Web) | **Minimal** (Wi-Fi tasks paused) |
| **Primary Benefit / Action** | Baseline | Shows absolute hardware-level limits. | Python CLI on Raspberry Pi / PC | Prevents MTU-Timeout; closes connection to save battery. | Bypasses ~200 ms OTA service discovery. | Bypasses active scan window delay (~216 ms). | Eliminates RF coexistence delay completely |

### Footnotes:
* **[1] ESPHome Stock Values:** Obtained as average values from the original latency logs. The physical connection duration fluctuates depending on signal strength and the advertising interval of the lock.
* **[2] Python keyble Values:** Estimated based on syslog timestamps (seconds resolution) of a typical run: Command received at `12:51:14`, BLE connected and command sent at `12:51:16`, status updated to UNLOCKED and disconnected at `12:51:20`. Total time to motor start is estimated at ~2.5s.

---

##  Configuration Setup

### ESPHome SDK Configuration
To enable persistent GATT caching across ESP32 reboots, ensure your `sdkconfig_options` inside the YAML contains the following:

```yaml
esp32:
  board: esp32dev
  framework:
    type: esp-idf
    sdkconfig_options:
      CONFIG_BOOTLOADER_WDT_TIME_MS: "60000"
      CONFIG_BT_GATTC_CACHE_NVS_FLASH: "y" # <-- Enables flash caching of handles
```

The file below details the benchmarks that were done enroute.

[walkthrough.md](https://github.com/user-attachments/files/28641233/walkthrough.md)
