### PR TITLE
Fix compilation on ESPHome 2026.8.0 (to_string → to_str)

### DIFF
--- a/components/eqiva_ble/eqiva_listener.cpp
+++ b/components/eqiva_ble/eqiva_listener.cpp
@@ -12,7 +12,7 @@ static const char *const TAG = "eqiva_ble";
 bool EqivaListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
     for (auto &it : device.get_manufacturer_datas()) {
         if (it.uuid == esp32_ble_tracker::ESPBTUUID::from_uint16(0x1A00)) {
-            ESP_LOGI(TAG, "Found Eqiva device (MAC: %s) (UUID): %s  (Name): %s", device.address_str().c_str(), it.uuid.to_string().c_str(), device.get_name().c_str());
+            ESP_LOGI(TAG, "Found Eqiva device (MAC: %s) (UUID): %s  (Name): %s", device.address_str().c_str(), it.uuid.to_str().c_str(), device.get_name().c_str());
             return true;
         }
     }


### PR DESCRIPTION
Fixes #54 — ESPHome 2026.8.0 renamed ESPBTUUID::to_string() to to_str(). This renames the call in eqiva_listener.cpp.