### PR TITLE
Fix compilation on ESPHome 2026.8.0: adapt to new ESPBTUUID::to_str()…

### DIFF
--- a/components/eqiva_ble/eqiva_listener.cpp
+++ b/components/eqiva_ble/eqiva_listener.cpp
@@ -12,7 +12,8 @@ static const char *const TAG = "eqiva_ble";
 bool EqivaListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
     for (auto &it : device.get_manufacturer_datas()) {
         if (it.uuid == esp32_ble_tracker::ESPBTUUID::from_uint16(0x1A00)) {
-            ESP_LOGI(TAG, "Found Eqiva device (MAC: %s) (UUID): %s  (Name): %s", device.address_str().c_str(), it.uuid.to_string().c_str(), device.get_name().c_str());
+            char uuid_buf[37];  // ESPBTUUID::UUID_STR_LEN
+            ESP_LOGI(TAG, "Found Eqiva device (MAC: %s) (UUID): %s  (Name): %s", device.address_str().c_str(), it.uuid.to_str(uuid_buf), device.get_name().c_str());
             return true;
         }
     }


### PR DESCRIPTION
… API

ESPHome 2026.8.0 replaced ESPBTUUID::to_string() (returning std::string) with to_str(char *buf), which writes into a caller-provided buffer of UUID_STR_LEN (37) bytes. Adapt the log call in eqiva_listener.cpp.

Fixes #54